### PR TITLE
Hotfix: Naamgeving gewijzigd voor correcte beschrijving 'Bought Products' pagina

### DIFF
--- a/Grocery.App/Views/GroceryListsView.xaml
+++ b/Grocery.App/Views/GroceryListsView.xaml
@@ -7,7 +7,7 @@
              x:DataType="vm:GroceryListViewModel"
              Title="GroceryListsView">
     <ContentPage.ToolbarItems>
-        <ToolbarItem Text="{Binding ClientName}" Command="{Binding ShowBoughtProductsCommand}" />
+        <ToolbarItem Text="Bought Products" Command="{Binding ShowBoughtProductsCommand}" />
     </ContentPage.ToolbarItems>
     <Shell.TitleView>
         <Grid>


### PR DESCRIPTION
Naamgeving gewijzigd van {ClientName} > "Bought Products" voor verduidelijking van de navigatie naar Bought Products pagina.